### PR TITLE
refactor(typesafeconfig): use interface for logger

### DIFF
--- a/logging/interface.go
+++ b/logging/interface.go
@@ -1,0 +1,14 @@
+package logging
+
+type Logger interface {
+	Debug(msg string, tags ...Tag)
+	Info(msg string, tags ...Tag)
+	Warn(msg string, tags ...Tag)
+	Error(msg string, tags ...Tag)
+	Fatal(msg string, tags ...Tag)
+}
+
+type Tag interface {
+	Key() string
+	Value() interface{}
+}

--- a/typesafeconfig/typesafe_config.go
+++ b/typesafeconfig/typesafe_config.go
@@ -36,6 +36,7 @@ import (
 	"embed"
 	"errors"
 	"fmt"
+	"github.com/armory-io/go-commons/logging"
 	"github.com/armory-io/go-commons/secrets"
 	"github.com/mitchellh/mapstructure"
 	"go.uber.org/multierr"
@@ -53,7 +54,7 @@ import (
 var ErrNoConfigurationSourcesProvided = errors.New("no configuration sources provided, you must provide at least 1 embed.FS or dir path")
 
 type resolver struct {
-	log                 *zap.SugaredLogger
+	log                 logging.Logger
 	embeddedFilesystems []*embed.FS
 	configurationDirs   []string
 	baseNames           []string


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/711726/181842891-4dbedd85-d923-4742-a807-8fc7eef5cf30.png)

:point_up: tests still pass when passing in a zap logger