### PR TITLE
feat(logging): enhance logging module to add default app metadata fields

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -21,16 +21,16 @@ import (
 	armoryhttp "github.com/armory-io/go-commons/http"
 	"github.com/armory-io/go-commons/iam"
 	"github.com/armory-io/go-commons/logging"
+	"github.com/armory-io/go-commons/metadata"
 	"github.com/armory-io/go-commons/metrics"
 	"github.com/armory-io/go-commons/mysql"
 	"go.uber.org/fx"
 )
 
-// Settings defines required settings for the application module.
-type Settings struct {
+// Configuration defines required settings for the application module.
+type Configuration struct {
 	fx.Out
 
-	Logging  logging.Settings
 	Server   armoryhttp.ServerSettings
 	Metrics  metrics.Settings
 	Auth     iam.Settings
@@ -38,7 +38,8 @@ type Settings struct {
 }
 
 var Module = fx.Module("armory-application",
-	fx.Provide(logging.New),
+	logging.Module,
+	metadata.Module,
 	fx.Provide(metrics.New),
 	fx.Provide(iam.New),
 	fx.Provide(gin.NewGinServer),

--- a/envutils/utils.go
+++ b/envutils/utils.go
@@ -1,0 +1,40 @@
+package envutils
+
+import "os"
+
+const (
+	armoryApplicationName    = "ARMORY_APPLICATION_NAME"
+	armoryEnvironmentName    = "ARMORY_ENVIRONMENT_NAME"
+	armoryReplicaSetName     = "ARMORY_REPLICA_SET_NAME"
+	armoryApplicationVersion = "ARMORY_APPLICATION_VERSION"
+	local                    = "local"
+)
+
+// GetEnvVarOrDefault looks up an env var by its key and returns the value it's non-empty else the default is returned.
+func GetEnvVarOrDefault(key, defaultValue string) string {
+	v := os.Getenv(key)
+	if v == "" {
+		return defaultValue
+	}
+	return v
+}
+
+// GetArmoryApplicationName returns the value of the ARMORY_APPLICATION_NAME env var else it defaults to empty string
+func GetArmoryApplicationName() string {
+	return os.Getenv(armoryApplicationName)
+}
+
+// GetArmoryEnvironmentName returns the value of the ARMORY_ENVIRONMENT_NAME env var if present else it defaults to local
+func GetArmoryEnvironmentName() string {
+	return GetEnvVarOrDefault(armoryEnvironmentName, local)
+}
+
+// GetArmoryReplicaSetName returns the value of the ARMORY_REPLICA_SET_NAME env var if present else an empty string
+func GetArmoryReplicaSetName() string {
+	return os.Getenv(armoryReplicaSetName)
+}
+
+// GetArmoryApplicationVersion returns the value of ARMORY_APPLICATION_VERSION or else defaults to "unset"
+func GetArmoryApplicationVersion() string {
+	return GetEnvVarOrDefault(armoryApplicationVersion, "unset")
+}

--- a/go.mod
+++ b/go.mod
@@ -12,13 +12,11 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/hashicorp/vault/api v1.7.2
 	github.com/hashicorp/vault/sdk v0.5.3
-	github.com/imdario/mergo v0.3.12
 	github.com/lestrrat-go/jwx v1.2.25
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/otiai10/copy v1.7.0
 	github.com/prometheus/client_golang v1.12.2
 	github.com/sirupsen/logrus v1.9.0
-	github.com/spf13/afero v1.6.0
 	github.com/stretchr/testify v1.8.0
 	github.com/uber-go/tally/v4 v4.1.2
 	go.uber.org/fx v1.17.1

--- a/go.sum
+++ b/go.sum
@@ -744,7 +744,6 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
-github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/intel/goresctrl v0.2.0/go.mod h1:+CZdzouYFn5EsxgqAQTEzMfwKwuc0fVdMrT9FCCAVRQ=
@@ -1170,7 +1169,6 @@ github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasO
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/afero v1.3.3/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY520V4=
-github.com/spf13/afero v1.6.0 h1:xoax2sJ2DT8S8xA2paPFjDCScCNeWsg75VG0DLRreiY=
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.2-0.20171109065643-2da4a54c5cee/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=

--- a/metadata/application_metadata.go
+++ b/metadata/application_metadata.go
@@ -1,0 +1,33 @@
+package metadata
+
+import (
+	"github.com/armory-io/go-commons/envutils"
+	"go.uber.org/fx"
+	"os"
+)
+
+type ApplicationMetadata struct {
+	Name        string
+	Version     string
+	Environment string
+	Replicaset  string
+	Hostname    string
+}
+
+func ApplicationMetadataProvider() ApplicationMetadata {
+	hostname, _ := os.Hostname()
+	if hostname == "" {
+		hostname = "unknown"
+	}
+	return ApplicationMetadata{
+		Name:        envutils.GetArmoryApplicationName(),
+		Version:     envutils.GetArmoryApplicationVersion(),
+		Environment: envutils.GetArmoryEnvironmentName(),
+		Replicaset:  envutils.GetArmoryReplicaSetName(),
+		Hostname:    hostname,
+	}
+}
+
+var Module = fx.Options(
+	fx.Provide(ApplicationMetadataProvider),
+)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/711726/182970078-4f749d00-4894-4c28-b3eb-a3aba786685b.png)

:point_up: applied it to local yeti, and you can see it bootstrapped a dev logger (for local) and added some base fields.

![image](https://user-images.githubusercontent.com/711726/182970255-01e88366-f959-42a5-84d1-cfd2b25671b5.png)

:point_up: if I add some more env vars :point_down: you can see there is even more logging context 

![image](https://user-images.githubusercontent.com/711726/182970308-db311e44-3bf5-4e31-8799-e3343d6a3a86.png)

setting `ARMORY_ENVIRONMENT_NAME=prod`

```json
{"level":"info","ts":1659654796.2720914,"caller":"typesafeconfig/typesafe_config.go:316","msg":"successfully loaded candidate: /home/fieldju/.armory/yeti.yaml","app":"yeti","environment":"prod","replicaset":"foobar1","hostname":"fieldju-desktop","version":"1.0.0-SNAPSHOT"}
```