### PR TITLE
feat(logging): source dimensions from multiple env vars

### DIFF
--- a/envutils/utils.go
+++ b/envutils/utils.go
@@ -1,12 +1,18 @@
 package envutils
 
-import "os"
+import (
+	"os"
+	"strings"
+)
 
 const (
 	armoryApplicationName    = "ARMORY_APPLICATION_NAME"
 	armoryEnvironmentName    = "ARMORY_ENVIRONMENT_NAME"
 	armoryReplicaSetName     = "ARMORY_REPLICA_SET_NAME"
 	armoryApplicationVersion = "ARMORY_APPLICATION_VERSION"
+	applicationName          = "APPLICATION_NAME"
+	applicationEnv           = "APPLICATION_ENVIRONMENT"
+	applicationVersion       = "APPLICATION_VERSION"
 	local                    = "local"
 )
 
@@ -21,12 +27,23 @@ func GetEnvVarOrDefault(key, defaultValue string) string {
 
 // GetArmoryApplicationName returns the value of the ARMORY_APPLICATION_NAME env var else it defaults to empty string
 func GetArmoryApplicationName() string {
-	return os.Getenv(armoryApplicationName)
+	name := os.Getenv(applicationName)
+	if name == "" {
+		name = os.Getenv(armoryApplicationName)
+	}
+	return strings.ToLower(name)
 }
 
 // GetArmoryEnvironmentName returns the value of the ARMORY_ENVIRONMENT_NAME env var if present else it defaults to local
 func GetArmoryEnvironmentName() string {
-	return GetEnvVarOrDefault(armoryEnvironmentName, local)
+	envName := os.Getenv(applicationEnv)
+	if envName == "" {
+		envName = os.Getenv(armoryEnvironmentName)
+	}
+	if envName == "" {
+		envName = local
+	}
+	return strings.ToLower(envName)
 }
 
 // GetArmoryReplicaSetName returns the value of the ARMORY_REPLICA_SET_NAME env var if present else an empty string
@@ -36,5 +53,12 @@ func GetArmoryReplicaSetName() string {
 
 // GetArmoryApplicationVersion returns the value of ARMORY_APPLICATION_VERSION or else defaults to "unset"
 func GetArmoryApplicationVersion() string {
-	return GetEnvVarOrDefault(armoryApplicationVersion, "unset")
+	version := os.Getenv(applicationVersion)
+	if version == "" {
+		version = os.Getenv(armoryApplicationVersion)
+	}
+	if version == "" {
+		version = "unset"
+	}
+	return version
 }

--- a/envutils/utils.go
+++ b/envutils/utils.go
@@ -25,8 +25,8 @@ func GetEnvVarOrDefault(key, defaultValue string) string {
 	return v
 }
 
-// GetArmoryApplicationName returns the value of the ARMORY_APPLICATION_NAME env var else it defaults to empty string
-func GetArmoryApplicationName() string {
+// GetApplicationName returns the value of the ARMORY_APPLICATION_NAME env var else it defaults to empty string
+func GetApplicationName() string {
 	name := os.Getenv(applicationName)
 	if name == "" {
 		name = os.Getenv(armoryApplicationName)
@@ -34,8 +34,8 @@ func GetArmoryApplicationName() string {
 	return strings.ToLower(name)
 }
 
-// GetArmoryEnvironmentName returns the value of the ARMORY_ENVIRONMENT_NAME env var if present else it defaults to local
-func GetArmoryEnvironmentName() string {
+// GetEnvironmentName returns the value of the ARMORY_ENVIRONMENT_NAME env var if present else it defaults to local
+func GetEnvironmentName() string {
 	envName := os.Getenv(applicationEnv)
 	if envName == "" {
 		envName = os.Getenv(armoryEnvironmentName)
@@ -46,13 +46,13 @@ func GetArmoryEnvironmentName() string {
 	return strings.ToLower(envName)
 }
 
-// GetArmoryReplicaSetName returns the value of the ARMORY_REPLICA_SET_NAME env var if present else an empty string
-func GetArmoryReplicaSetName() string {
+// GetReplicaSetName returns the value of the ARMORY_REPLICA_SET_NAME env var if present else an empty string
+func GetReplicaSetName() string {
 	return os.Getenv(armoryReplicaSetName)
 }
 
-// GetArmoryApplicationVersion returns the value of ARMORY_APPLICATION_VERSION or else defaults to "unset"
-func GetArmoryApplicationVersion() string {
+// GetApplicationVersion returns the value of ARMORY_APPLICATION_VERSION or else defaults to "unset"
+func GetApplicationVersion() string {
 	version := os.Getenv(applicationVersion)
 	if version == "" {
 		version = os.Getenv(armoryApplicationVersion)

--- a/metadata/application_metadata.go
+++ b/metadata/application_metadata.go
@@ -20,10 +20,10 @@ func ApplicationMetadataProvider() ApplicationMetadata {
 		hostname = "unknown"
 	}
 	return ApplicationMetadata{
-		Name:        envutils.GetArmoryApplicationName(),
-		Version:     envutils.GetArmoryApplicationVersion(),
-		Environment: envutils.GetArmoryEnvironmentName(),
-		Replicaset:  envutils.GetArmoryReplicaSetName(),
+		Name:        envutils.GetApplicationName(),
+		Version:     envutils.GetApplicationVersion(),
+		Environment: envutils.GetEnvironmentName(),
+		Replicaset:  envutils.GetReplicaSetName(),
 		Hostname:    hostname,
 	}
 }


### PR DESCRIPTION
Helm chart sets env vars in addition to Armory Cloud setting env vars

![image](https://user-images.githubusercontent.com/711726/183513071-83125048-6440-466d-8bc1-e1fd2f52849c.png)
