### PR TITLE
fix(mysql): use proper logger, not global logger

### DIFF
--- a/mysql/migration.go
+++ b/mysql/migration.go
@@ -23,7 +23,6 @@ import (
 	"github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/database/mysql"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
-	log "github.com/sirupsen/logrus"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
 	"time"
@@ -133,7 +132,7 @@ func (m *Migrator) migrate() error {
 	}
 	err = migrationInstance.Up()
 	if err == migrate.ErrNoChange {
-		log.Infof("No change detected.")
+		m.log.Infof("No change detected.")
 		return nil
 	}
 	return err


### PR DESCRIPTION
Was testing that my changes to go commons where backwards compatible with Yeti and noticed one of these lines was not like the others 😱

![image](https://user-images.githubusercontent.com/711726/195217442-b3b406d4-b134-4283-9e25-e1775a7d65aa.png)

![image](https://user-images.githubusercontent.com/711726/195217504-0fb7e6c9-844c-47f1-bd73-cec86cd12c0f.png)

