### PR TITLE
refactor(metrics): move metrics endpoint to be on same port as other management endpoints

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -59,7 +59,7 @@ var ModuleV2 = fx.Options(
 	management.Module,
 	tracing.Module,
 	fx.Provide(
-		metrics.New,
+		metrics.NewSvc,
 		iam.New,
 		info.New,
 		func(ps *iam.ArmoryCloudPrincipalService) server.AuthService {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -68,11 +68,12 @@ func NewSvc(lc fx.Lifecycle, app metadata.ApplicationMetadata) *Metrics {
 		Separator:       tallyprom.DefaultSeparator,
 		SanitizeOptions: &sanitizeOptions,
 		Tags: map[string]string{
-			"appName":     app.Name,
-			"version":     app.Version,
-			"hostname":    app.Hostname,
-			"environment": app.Environment,
-			"replicaset":  app.Replicaset,
+			"appName":      app.Name,
+			"version":      app.Version,
+			"hostname":     app.Hostname,
+			"environment":  app.Environment,
+			"replicaset":   app.Replicaset,
+			"deploymentId": app.DeploymentId,
 		},
 	}
 	scope, closer := tally.NewRootScope(scopeOpts, time.Second)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -58,7 +58,7 @@ type Metrics struct {
 	rootScope tally.Scope
 }
 
-// NewSvc creates an instance of the metrics service but does not start a server for metrics scrapping.
+// NewSvc creates an instance of the metrics service but does not start a server for metrics scraping.
 // Serving the open metrics endpoint is handled by a management endpoint, see the management package.
 func NewSvc(lc fx.Lifecycle, app metadata.ApplicationMetadata) *Metrics {
 	registerer := prometheus.DefaultRegisterer


### PR DESCRIPTION
As I discussed in Zoom, this will require that we update the Helm Values of our services when we update go-commons to move the port from 3001 -> xxxx.