### PR TITLE
bugfix: make transactionBuilder available outside FX

### DIFF
--- a/mysql/sql_transaction.go
+++ b/mysql/sql_transaction.go
@@ -27,11 +27,11 @@ var (
 	ErrTxAlreadyClosed = errors.New("transaction is already closed")
 	TxModule           = fx.Module(
 		"mysqlTx",
-		fx.Provide(initializeModule),
+		fx.Provide(InitializeModule),
 	)
 )
 
-func initializeModule(db *sql.DB, log *zap.SugaredLogger) TransactionScopeBuilder {
+func InitializeModule(db *sql.DB, log *zap.SugaredLogger) TransactionScopeBuilder {
 
 	return func(ctx context.Context, isolationLevel sql.IsolationLevel) (TransactionScopeWrapper, error) {
 		var targetCtx contextWithTx

--- a/mysql/sql_trasnaction_test.go
+++ b/mysql/sql_trasnaction_test.go
@@ -33,7 +33,7 @@ func TestSqlTransaction(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	txScopeBuilder := initializeModule(mysqlDb, logger)
+	txScopeBuilder := InitializeModule(mysqlDb, logger)
 
 	defer mysqlDb.Close()
 


### PR DESCRIPTION
For testing purposes it makes sense to make the Initialze method public - so we don't need to setup complete FX DI to update tests.