### PR TITLE
refactor(server): enable raw byte requests and octet-stream responses

### DIFF
--- a/typesafeconfig/config.go
+++ b/typesafeconfig/config.go
@@ -221,7 +221,7 @@ func resolveTemplates(config map[string]any) error {
 func resolveSecrets(config map[string]any, log *zap.SugaredLogger) error {
 	return recurseStringValuesAndMap(config, func(value string) (string, error) {
 		if secrets.IsEncryptedSecret(value) {
-			log.Infof("Attempting to resolve actual value for: '%s'", color.New(color.FgHiGreen).Sprintf(value))
+			log.Infof("attempting to resolve actual value for: '%s'", color.New(color.FgHiGreen).Sprintf(value))
 			d, err := secrets.NewDecrypter(context.Background(), value)
 			if err != nil {
 				return value, multierr.Append(fmt.Errorf("failed to create decrypter for '%s'", value), err)


### PR DESCRIPTION
Needed for things like Github Webhooks where the SDK wants the raw bytes for parsing:
https://github.com/armory-io/infra-devops-bot/blob/6fd598c280cd4ec98c7a9f0da5a37d78d23f67d4/internal/bot/controllers/webhook.go#L49-L58