### PR TITLE
bugfix: added 'azp' property from Auth0 token

### DIFF
--- a/iam/jwt.go
+++ b/iam/jwt.go
@@ -26,9 +26,10 @@ import (
 )
 
 const (
-	scopeClaim = "scope"
-	subject    = "sub"
-	issuer     = "iss"
+	scopeClaim      = "scope"
+	subject         = "sub"
+	issuer          = "iss"
+	authorizedParty = "azp"
 )
 
 type JwtFetcher interface {
@@ -82,6 +83,10 @@ func (j *JwtToken) Fetch(token []byte) (interface{}, interface{}, error) {
 	}
 	untypedPrincipal.(map[string]interface{})[subject] = parsedJwt.Subject()
 	untypedPrincipal.(map[string]interface{})[issuer] = parsedJwt.Issuer()
+	azp, provided := parsedJwt.Get(authorizedParty)
+	if provided {
+		untypedPrincipal.(map[string]interface{})[authorizedParty] = azp
+	}
 
 	scopes, _ := parsedJwt.Get(scopeClaim)
 

--- a/iam/principal.go
+++ b/iam/principal.go
@@ -32,40 +32,28 @@ const (
 
 type ArmoryCloudPrincipal struct {
 
-	/** The type of principal, user or machine */
+	//  PrincipalType The type of principal, user or machine
 	Type PrincipalType `json:"type"`
-	/**
-	 * This is the principals name For user types this is will the users email address For machine
-	 * types this will be the identifier of the OIDC application that represents the machine
-	 */
+	// Name  This is the principals name For user types this is will the users email address For machine  types this will be the identifier of the OIDC application that represents the machine
 	Name string `json:"name"`
-	/** The guid for the organization the principal is a member of */
+	// OrgId The guid for the organization the principal is a member of
 	OrgId string `json:"orgId"`
-	/** The human-readable name of the organization */
+	// OrgName The human-readable name of the organization
 	OrgName string `json:"orgName"`
-	/** The guid for the environment (aka tenant) that this principal is authorized for */
+	// EnvId The guid for the environment (aka tenant) that this principal is authorized for
 	EnvId string `json:"envId"`
-	/**
-	 * A flag to determine if the principal is an armory admin principal and can do dangerous x-org
-	 * and or x-env actions.
-	 */
+	// ArmoryAdmin A flag to determine if the principal is an armory admin principal and can do dangerous x-org and or x-env actions.
 	ArmoryAdmin bool `json:"armoryAdmin"`
-	/** The "sub" (subject) claim identifies the principal that is the
-	subject of the JWT.  The "sub" value is a case-sensitive string containing a StringOrURI value. */
+	// Subject  The "sub" (subject) claim identifies the principal that is the subject of the JWT.  The "sub" value is a case-sensitive string containing a StringOrURI value.
 	Subject string `json:"sub"`
-	/** The "iss" (issuer) claim identifies the principal that issued the JWT.*/
+	/// Issuer The "iss" (issuer) claim identifies the principal that issued the JWT.
 	Issuer string `json:"iss"`
-	/**
-	 * OPTIONAL. Authorized party - the party to which the ID Token was issued. If present, it MUST
-	 * contain the OAuth 2.0 Client ID of this party. This Claim is only needed when the ID Token has
-	 * a single audience value and that audience is different from the authorized party. It MAY be
-	 * included even when the authorized party is the same as the sole audience. The azp value is a
-	 * case-sensitive string containing a StringOrURI value.
-	 */
-	AuthorizedParty *string `json:"azp"`
-	/** A list of scopes that was set by the authorization server such as use:adminApi */
+	// AuthorizedParty OPTIONAL. Authorized party - the party to which the ID Token was issued. If present, it MUST contain the OAuth 2.0 Client ID of this party. This Claim is only needed when the ID Token has
+	// a single audience value and that audience is different from the authorized party. It MAY be included even when the authorized party is the same as the sole audience. The azp value is a case-sensitive string containing a StringOrURI value.
+	AuthorizedParty string `json:"azp"`
+	// Scopes A list of scopes that was set by the authorization server such as use:adminApi
 	Scopes []string `json:"scopes"`
-	/** List of groups that a principal belongs to */
+	// Roles List of groups that a principal belongs to
 	Roles []string `json:"roles"`
 }
 

--- a/iam/principal.go
+++ b/iam/principal.go
@@ -31,17 +31,42 @@ const (
 )
 
 type ArmoryCloudPrincipal struct {
-	Type            PrincipalType `json:"type"`
-	Name            string        `json:"name"`
-	OrgId           string        `json:"orgId"`
-	OrgName         string        `json:"orgName"`
-	EnvId           string        `json:"envId"`
-	ArmoryAdmin     bool          `json:"armoryAdmin"`
-	Subject         string        `json:"sub"`
-	Issuer          string        `json:"iss"`
-	AuthorizedParty string        `json:"azp"`
-	Scopes          []string      `json:"scopes"`
-	Roles           []string      `json:"roles"`
+
+	/** The type of principal, user or machine */
+	Type PrincipalType `json:"type"`
+	/**
+	 * This is the principals name For user types this is will the users email address For machine
+	 * types this will be the identifier of the OIDC application that represents the machine
+	 */
+	Name string `json:"name"`
+	/** The guid for the organization the principal is a member of */
+	OrgId string `json:"orgId"`
+	/** The human-readable name of the organization */
+	OrgName string `json:"orgName"`
+	/** The guid for the environment (aka tenant) that this principal is authorized for */
+	EnvId string `json:"envId"`
+	/**
+	 * A flag to determine if the principal is an armory admin principal and can do dangerous x-org
+	 * and or x-env actions.
+	 */
+	ArmoryAdmin bool `json:"armoryAdmin"`
+	/** The "sub" (subject) claim identifies the principal that is the
+	subject of the JWT.  The "sub" value is a case-sensitive string containing a StringOrURI value. */
+	Subject string `json:"sub"`
+	/** The "iss" (issuer) claim identifies the principal that issued the JWT.*/
+	Issuer string `json:"iss"`
+	/**
+	 * OPTIONAL. Authorized party - the party to which the ID Token was issued. If present, it MUST
+	 * contain the OAuth 2.0 Client ID of this party. This Claim is only needed when the ID Token has
+	 * a single audience value and that audience is different from the authorized party. It MAY be
+	 * included even when the authorized party is the same as the sole audience. The azp value is a
+	 * case-sensitive string containing a StringOrURI value.
+	 */
+	AuthorizedParty *string `json:"azp"`
+	/** A list of scopes that was set by the authorization server such as use:adminApi */
+	Scopes []string `json:"scopes"`
+	/** List of groups that a principal belongs to */
+	Roles []string `json:"roles"`
 }
 
 func (p *ArmoryCloudPrincipal) Tenant() string {

--- a/iam/principal.go
+++ b/iam/principal.go
@@ -31,16 +31,17 @@ const (
 )
 
 type ArmoryCloudPrincipal struct {
-	Type        PrincipalType `json:"type"`
-	Name        string        `json:"name"`
-	OrgId       string        `json:"orgId"`
-	OrgName     string        `json:"orgName"`
-	EnvId       string        `json:"envId"`
-	ArmoryAdmin bool          `json:"armoryAdmin"`
-	Subject     string        `json:"sub"`
-	Issuer      string        `json:"iss"`
-	Scopes      []string      `json:"scopes"`
-	Roles       []string      `json:"roles"`
+	Type            PrincipalType `json:"type"`
+	Name            string        `json:"name"`
+	OrgId           string        `json:"orgId"`
+	OrgName         string        `json:"orgName"`
+	EnvId           string        `json:"envId"`
+	ArmoryAdmin     bool          `json:"armoryAdmin"`
+	Subject         string        `json:"sub"`
+	Issuer          string        `json:"iss"`
+	AuthorizedParty string        `json:"azp"`
+	Scopes          []string      `json:"scopes"`
+	Roles           []string      `json:"roles"`
 }
 
 func (p *ArmoryCloudPrincipal) Tenant() string {

--- a/iam/principal_service_test.go
+++ b/iam/principal_service_test.go
@@ -1,7 +1,6 @@
 package iam
 
 import (
-	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -36,7 +35,7 @@ func TestTokenToPrincipal(t *testing.T) {
 		ArmoryAdmin:     false,
 		Subject:         "test_subject_123",
 		Issuer:          "https://test.issuer/",
-		AuthorizedParty: lo.ToPtr("authorized party"),
+		AuthorizedParty: "authorized party",
 		Scopes: []string{
 			"api:organization:full",
 			"openid",

--- a/iam/principal_service_test.go
+++ b/iam/principal_service_test.go
@@ -1,6 +1,7 @@
 package iam
 
 import (
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -21,19 +22,21 @@ func TestTokenToPrincipal(t *testing.T) {
 		},
 		"iss": "https://test.issuer/",
 		"sub": "test_subject_123",
+		"azp": "authorized party",
 	}
 	scopes := "openid profile email"
 	principal, err := tokenToPrincipal(token, scopes)
 	assert.NoError(t, err)
 	assert.Equal(t, ArmoryCloudPrincipal{
-		Name:        "frankie",
-		Type:        User,
-		OrgId:       "org-id",
-		OrgName:     "dogz that deploy",
-		EnvId:       "env-id",
-		ArmoryAdmin: false,
-		Subject:     "test_subject_123",
-		Issuer:      "https://test.issuer/",
+		Name:            "frankie",
+		Type:            User,
+		OrgId:           "org-id",
+		OrgName:         "dogz that deploy",
+		EnvId:           "env-id",
+		ArmoryAdmin:     false,
+		Subject:         "test_subject_123",
+		Issuer:          "https://test.issuer/",
+		AuthorizedParty: lo.ToPtr("authorized party"),
 		Scopes: []string{
 			"api:organization:full",
 			"openid",


### PR DESCRIPTION
For user credentials, the property "iss" contains reference to "auth0_id" in user table, but for client credentials, that data is provided via "azp" property. So - in order to match client_credentials to content of the token - i need to query the "azp" (Authorized Party) property. This PR adds this property to the ArmoryPrincipal object. 