### PR TITLE
chore: trim noise off of panic stacktrace

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -525,6 +525,7 @@ func ginHOF[REQUEST, RESPONSE any](
 					errInternalServerError,
 					serr.WithErrorMessage("The handler panicked"),
 					serr.WithStackTraceLoggingBehavior(serr.ForceStackTrace),
+					serr.WithFrameSkips(6),
 					serr.WithCause(fmt.Errorf(cause)),
 				), logger)
 			}


### PR DESCRIPTION
FROM:
![image](https://user-images.githubusercontent.com/711726/203817828-4b5c716a-01cb-4705-86ea-63a9e7899184.png)

TO:
![image](https://user-images.githubusercontent.com/711726/203818126-3235ca8f-a061-4af7-b96b-2c7ccca4b879.png)

:point_up: the stacktrace's first item now takes you directly to the source of the panic vs having to dig through a few frames to find the actual source of the panic