### PR TITLE
feat: use init-container to apply migrations

### DIFF
--- a/mysql/module.go
+++ b/mysql/module.go
@@ -23,3 +23,9 @@ var Module = fx.Module(
 	fx.Provide(New),
 	fx.Invoke(NewMigrator),
 )
+
+var ModuleV2 = fx.Module(
+	"sql",
+	fx.Provide(New),
+	fx.Invoke(NewMigratorV2),
+)


### PR DESCRIPTION
This functionality adds possibility to apply migration to a fixed version. Migrations are stored in https://github.com/armory-io/infra-armory-db-migrations repository and are published as tiny docker container (5 MB in size). 

Container is loaded at pod's start time and migrations are copied to /[service]_migrations folder, where migrator can pick them up. 