### PR TITLE
fix: better handling of registry to avoid duplicate registration error on app start

### DIFF
--- a/server/handler_test_utils.go
+++ b/server/handler_test_utils.go
@@ -172,7 +172,7 @@ func (h *HandlerTestContext) BuildHandler(t *testing.T) (*gin.Context, gin.Handl
 		h.ginContext.Request = h.ginContext.Request.WithContext(iam.DangerouslyWriteUnverifiedPrincipalToContext(ctx, h.principal))
 	}
 
-	registryData := make(map[handlerDTOKey]map[string]*handlerDTO)
+	registryData := make(map[handlerDTOKey]map[handlerDTOMimeTypeKey]*handlerDTO)
 	err := configureHandler(h.selectedHandler, h.controller, h.logger, h.validate, registryData)
 	if err != nil {
 		t.Fatal("failed to create handler configuration", err)

--- a/server/registry_test.go
+++ b/server/registry_test.go
@@ -72,7 +72,7 @@ func (p testController) Handlers() []Handler {
 }
 
 func (s *RegistryTestSuite) TestRegisterHandlersWithSameProducesAndConsumesCombination() {
-	registryData := map[handlerDTOKey]map[string]*handlerDTO{}
+	registryData := map[handlerDTOKey]map[handlerDTOMimeTypeKey]*handlerDTO{}
 	for _, handler := range s.controller.Handlers() {
 		err := configureHandler(handler, s.controller, s.log, nil, registryData)
 		s.NoError(err, "all handlers should register")


### PR DESCRIPTION
Also improving error for invalid mime types specified
![image](https://user-images.githubusercontent.com/1523593/217959510-ccbdbbb5-8218-4f70-bfb2-421e69aef31b.png)

The error message now includes available combinations instead of just available `Accept` types