### PR TITLE
fix: for backward compatibility, support "super type" of Produces MediaType since consumer was previously not strict

### DIFF
--- a/server/registry_test.go
+++ b/server/registry_test.go
@@ -2,16 +2,20 @@ package server
 
 import (
 	"github.com/armory-io/go-commons/logging"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 )
 
 const (
-	test1JSON     = "application/test1+json"
-	test1LinkJSON = "application/test1.link+json"
+	test1JSON       = "application/test1+json"
+	test1LinkJSON   = "application/test1.link+json"
+	applicationJSON = "application/json"
 )
 
 type RegistryTestSuite struct {
@@ -43,6 +47,7 @@ func (p testController) Handlers() []Handler {
 			Consumes:   test1JSON,
 			Produces:   test1JSON,
 			Default:    true,
+			AuthOptOut: true,
 		}),
 		NewHandler(noop, HandlerConfig{
 			Path:       "/pipelines/kubernetes",
@@ -51,6 +56,7 @@ func (p testController) Handlers() []Handler {
 			Consumes:   test1LinkJSON,
 			Produces:   test1JSON,
 			Default:    false,
+			AuthOptOut: true,
 		}),
 		NewHandler(noop, HandlerConfig{
 			Path:       "/pipelines/kubernetes",
@@ -59,6 +65,7 @@ func (p testController) Handlers() []Handler {
 			Consumes:   test1JSON,
 			Produces:   test1LinkJSON,
 			Default:    false,
+			AuthOptOut: true,
 		}),
 		NewHandler(noop, HandlerConfig{
 			Path:       "/pipelines/kubernetes",
@@ -67,17 +74,40 @@ func (p testController) Handlers() []Handler {
 			Consumes:   test1LinkJSON,
 			Produces:   test1LinkJSON,
 			Default:    false,
+			AuthOptOut: true,
 		}),
 	}
 }
 
 func (s *RegistryTestSuite) TestRegisterHandlersWithSameProducesAndConsumesCombination() {
+	// When handlers are registered, there is no issue
 	registryData := map[handlerDTOKey]map[handlerDTOMimeTypeKey]*handlerDTO{}
 	for _, handler := range s.controller.Handlers() {
 		err := configureHandler(handler, s.controller, s.log, nil, registryData)
 		s.NoError(err, "all handlers should register")
 	}
 
+	// When a duplicate handler is registered, we get an error
 	err := configureHandler(s.controller.Handlers()[0], s.controller, s.log, nil, registryData)
 	s.ErrorIs(err, ErrDuplicateHandlerRegistered)
+
+	// We can use the registered handler even when a super type (i.e. application/json is specified and there isn't a specific consumer for it)
+	multiHandlerFn := createMultiMimeTypeFn(registryData[handlerDTOKey{
+		path:   "/pipelines/kubernetes",
+		method: http.MethodPost,
+	}], s.log)
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = &http.Request{
+		URL: &url.URL{
+			Path: "/pipelines/kubernetes",
+		},
+		Header: map[string][]string{
+			// Request with a super type - should find a default subtype handler and execute
+			"Content-Type": {applicationJSON},
+			"Accept":       {test1LinkJSON},
+		},
+		Method: "POST",
+	}
+	multiHandlerFn(c)
 }


### PR DESCRIPTION
After the last go-commons update around registry, the matching became more strict around finding an exact match on consumes for a handler that "produces" what was requested. The CLI was mistakenly sending "application/json" AND "application/vnd.armory....+json" as the Content-Types. The latter becomes ignored because it is the second value. Thus, the multiMimeType function looking for the handler found no match in spite the CLI supposedly being as specific as it needed to be. 

This doesn't fully forgive a non-matching Content-Type; it expects that you've at least specified "super type" like "application/json" where we support "application/myspecial+json". 

This was tested locally using Postman and specifying different Conten-Type and Accept header combinations. Third time is the charm, right? 