### PR TITLE
chore: update the dep bumper workflow to point to monorepo

### DIFF
--- a/.github/workflows/update-go-commons-projects.yaml
+++ b/.github/workflows/update-go-commons-projects.yaml
@@ -10,7 +10,7 @@ jobs:
       - name: trigger github go-commons updater workflow
         uses: benc-uk/workflow-dispatch@v1
         with:
-          ref: master
+          ref: main
           repo: armory-io/js-monorepo
           workflow: 'Devops - Update Go Commons'
           token: ${{ secrets.ARMORY_PLATFORM_GITHUB_PAT_TOKEN }}

--- a/.github/workflows/update-go-commons-projects.yaml
+++ b/.github/workflows/update-go-commons-projects.yaml
@@ -11,7 +11,7 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1
         with:
           ref: master
-          repo: armory-io/infra-armory-cloud-github-settings-scraper
-          workflow: Update Go Commons
+          repo: armory-io/js-monorepo
+          workflow: 'Devops - Update Go Commons'
           token: ${{ secrets.ARMORY_PLATFORM_GITHUB_PAT_TOKEN }}
           inputs: '{ "version": "${{ github.event.release.tag_name }}" }'


### PR DESCRIPTION
pending: https://github.com/armory-io/js-monorepo/pull/184